### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ $ accession --help
 usage: accession [-h] [--buffer_location BUFFER_LOCATION] [--buff BUFF]
                  [--verbosity VERBOSITY] [--resume RESUME]
                  [--source_root SOURCE_ROOT] [--filter_pattern FILTER_PATTERN]
-                 [--accessions_url ACCESSIONS_URL] [--receipt-dir RECEIPT_DIR]
-                 [--qremis-url QREMIS_URL] [--archstor_url ARCHSTOR_URL]
+                 [--accessions_url ACCESSIONS_URL] [--receipt_dir RECEIPT_DIR]
+                 [--qremis_url QREMIS_URL] [--archstor_url ARCHSTOR_URL]
                  [--confirm]
                  target accession_id
 
@@ -55,9 +55,9 @@ optional arguments:
                         Regexes to use to exclude files whose rel paths match.
   --accessions_url ACCESSIONS_URL
                         The url of the accessions idnest.
-  --receipt-dir RECEIPT_DIR
+  --receipt_dir RECEIPT_DIR
                         A directory to deposit receipt files in.
-  --qremis-url QREMIS_URL
+  --qremis_url QREMIS_URL
                         The URL of the root of the qremis API
   --archstor_url ARCHSTOR_URL
                         The URL of the root of the archstor API

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-# Archstor
+The qremis accutil is a utility for performing accessions in the qremis based microservice environment
+for a digital repository.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ for a digital repository.
 
 
 ## Usage
+
 ```
 $ accession --help
 usage: accession [-h] [--buffer_location BUFFER_LOCATION] [--buff BUFF]
@@ -24,6 +25,7 @@ usage: accession [-h] [--buffer_location BUFFER_LOCATION] [--buff BUFF]
                  [--source_root SOURCE_ROOT] [--filter_pattern FILTER_PATTERN]
                  [--accessions_url ACCESSIONS_URL] [--receipt-dir RECEIPT_DIR]
                  [--qremis-url QREMIS_URL] [--archstor_url ARCHSTOR_URL]
+                 [--confirm]
                  target accession_id
 
 positional arguments:
@@ -46,7 +48,8 @@ optional arguments:
                         Resume a previously started run by specifying
                         receipt(s) which contains errors.
   --source_root SOURCE_ROOT
-                        The root of the directory that needs to be accessioned.
+                        The root of the directory that needs to be
+                        accessioned.
   --filter_pattern FILTER_PATTERN
                         Regexes to use to exclude files whose rel paths match.
   --accessions_url ACCESSIONS_URL
@@ -56,5 +59,9 @@ optional arguments:
   --qremis-url QREMIS_URL
                         The URL of the root of the qremis API
   --archstor_url ARCHSTOR_URL
+                        The URL of the root of the archstor API
+  --confirm             Redownload all objects after uploading to confirm
+                        transfer to the object store. Utilizes the buffer
+                        location.
 ```
 * All URLs should include trailing slashes

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
+# accutil
+
+## About
+
 The qremis accutil is a utility for performing accessions in the qremis based microservice environment
 for a digital repository.
+
+
+## Related Projects
+
+- [qremis](https://github.com/bnbalsamo/qremis): A preservation metadata specification
+- [pyqremis](https://github.com/bnbalsamo/pyqremis): A python library for working with qremis
+- [qremiser](https://github.com/bnbalsamo/qremiser): A python library/microservice for generating qremis from files
+- [qremis_api](https://github.com/bnbalsamo/qremis_api): An API for managing qremis records
+- [archstor](https://github.com/bnbalsamo/archstor): A web gateway for unifying object storage technologies
+
+
+
+## Usage
+```
+$ accession --help
+usage: accession [-h] [--buffer_location BUFFER_LOCATION] [--buff BUFF]
+                 [--verbosity VERBOSITY] [--resume RESUME]
+                 [--source_root SOURCE_ROOT] [--filter_pattern FILTER_PATTERN]
+                 [--accessions_url ACCESSIONS_URL] [--receipt-dir RECEIPT_DIR]
+                 [--qremis-url QREMIS_URL] [--archstor_url ARCHSTOR_URL]
+                 target accession_id
+
+positional arguments:
+  target                The file/directory that needs to be ingested.
+  accession_id          The identifier of the accession the ingested material
+                        belongs to, or 'new' to mint a new accession
+                        identifier and apply it
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --buffer_location BUFFER_LOCATION
+                        A location on disk to save files briefly* from outside
+                        media to operate on. If not specified the application
+                        will read straight from the outside multiple times.
+  --buff BUFF           How much data to load into RAM in one go for various
+                        operations.
+  --verbosity VERBOSITY
+                        The verbosity of logs to emit.
+  --resume RESUME, -r RESUME
+                        Resume a previously started run by specifying
+                        receipt(s) which contains errors.
+  --source_root SOURCE_ROOT
+                        The root of the directory that needs to be accessioned.
+  --filter_pattern FILTER_PATTERN
+                        Regexes to use to exclude files whose rel paths match.
+  --accessions_url ACCESSIONS_URL
+                        The url of the accessions idnest.
+  --receipt-dir RECEIPT_DIR
+                        A directory to deposit receipt files in.
+  --qremis-url QREMIS_URL
+                        The URL of the root of the qremis API
+  --archstor_url ARCHSTOR_URL
+```
+* All URLs should include trailing slashes

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ for a digital repository.
 - [qremiser](https://github.com/bnbalsamo/qremiser): A python library/microservice for generating qremis from files
 - [qremis_api](https://github.com/bnbalsamo/qremis_api): An API for managing qremis records
 - [archstor](https://github.com/bnbalsamo/archstor): A web gateway for unifying object storage technologies
+- [idnest](https://github.com/uchicago-library/idnest): An API for nested identifier association.
 
 
 

--- a/accutil/__init__.py
+++ b/accutil/__init__.py
@@ -392,7 +392,7 @@ class AccUtil:
         )
         parser.add_argument(
             "--source_root", help="The root of the  " +
-            "directory that needs to be staged.",
+            "directory that needs to be accessioned.",
             type=str, action='store',
             default=None
         )

--- a/accutil/__init__.py
+++ b/accutil/__init__.py
@@ -411,11 +411,11 @@ class AccUtil:
             action='store', default=None
         )
         parser.add_argument(
-            "--receipt-dir", help="A directory to deposit receipt files in.",
+            "--receipt_dir", help="A directory to deposit receipt files in.",
             default=None
         )
         parser.add_argument(
-            "--qremis-url", help="The URL of the root of the qremis API",
+            "--qremis_url", help="The URL of the root of the qremis API",
             default=None
         )
         parser.add_argument(

--- a/accutil/__init__.py
+++ b/accutil/__init__.py
@@ -212,7 +212,7 @@ def secure_incoming_file(path, buffer_location, buff):
         buffered = False
         buffered_md5 = None
         original_md5 = md5(path, buff)
-    return path, original_md5, buffered, buffered_md5
+    return str(path), original_md5, buffered, buffered_md5
 
 
 def build_and_post_ingest_event(identifier, qremis_api_url):

--- a/accutil/__init__.py
+++ b/accutil/__init__.py
@@ -292,7 +292,7 @@ def build_and_post_initial_fixity_check_event(identifier, fixity_md5, qremis_api
     split_and_post_record(fixity_qremis_rec, qremis_api_url)
 
 
-def ingest_file(path, acc_id, buffer_location, buff, root, running_buffer_delete,
+def ingest_file(path, acc_id, buffer_location, buff, root,
                 archstor_url, acc_idnest_url, qremis_api_url):
 
     output = {}
@@ -343,7 +343,7 @@ def ingest_file(path, acc_id, buffer_location, buff, root, running_buffer_delete
 
         # If we buffered the file into safe storage somewhere in addition to the
         # origin media remove it now
-        if buffer_location is not None and running_buffer_delete:
+        if buffer_location is not None:
             remove(path)
         output['success'] = True
 
@@ -369,16 +369,6 @@ class AccUtil:
             "the ingested material belongs to, or 'new' to mint a new " +
             "accession identifier and apply it",
             type=str, action='store'
-        )
-        parser.add_argument(
-            "--running_buffer_delete",
-            help="If this argument is passed individual files will be " +
-            "deleted out of the buffer after they are POST'd to the " +
-            "ingress endpoint. If it isn't _you must clean up your " +
-            "buffer location manually_. If the location you are addressing " +
-            "is bigger than your buffering location, not passing this " +
-            "argument can result in your disk being filled.",
-            action='store_true', default=None
         )
         parser.add_argument(
             "--buffer_location", help="A location on disk to save " +
@@ -471,18 +461,6 @@ class AccUtil:
         else:
             self.buffer_location = None
         log.debug("buffer location: {}".format(str(self.buffer_location)))
-
-        if isinstance(args.running_buffer_delete, bool):
-            self.running_buffer_delete = args.running_buffer_delete
-        elif isinstance(config["DEFAULT"].getboolean(
-                "RUNNING_BUFFER_DELETE"), bool):
-            self.running_buffer_delete = config["DEFAULT"].getboolean(
-                "RUNNING_BUFFER_DELETE")
-        else:
-            self.running_buffer_delete = False
-        log.debug(
-            "running buffer delete: {}".format(str(self.running_buffer_delete))
-        )
 
         if args.receipt_dir:
             self.receipt_dir = args.receipt_dir
@@ -588,7 +566,7 @@ class AccUtil:
         return ingest_file(
             path, self.acc_id,
             self.buffer_location, self.buff, self.root,
-            self.running_buffer_delete, self.archstor_url,
+            self.archstor_url,
             self.acc_endpoint,
             self.qremis_url
         )


### PR DESCRIPTION
- Fixes the README
- splits .ingest_file() into several wrapped functions to keep functionality compartmentalized
- removes the redundant --running_buffer_delete flag
- standardizes CLI flags to use underscores
- writes qremis metadata to a specified qremis API
- makes initial fixity checks optional
- makes changes to the receipt format